### PR TITLE
Modif Model Offer and Schema

### DIFF
--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -3,4 +3,8 @@ class OffersController < ApplicationController
   def index
     @offers = Offer.all
   end
+
+  def search
+
+  end
 end

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -1,7 +1,9 @@
 class Offer < ApplicationRecord
-  belongs_to :user
   has_many :reviews, dependent: :destroy
+  belongs_to :user
 
   validates :title, presence: true
   validates :description, presence: true
+  validates :price, presence: true, numericality: true
+  validates :date, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,5 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_many :reviews, dependent: :destroy
+  has_many :offers
 end

--- a/db/migrate/20201117114919_add_foreign_key_to_offer.rb
+++ b/db/migrate/20201117114919_add_foreign_key_to_offer.rb
@@ -1,0 +1,5 @@
+class AddForeignKeyToOffer < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :offers, :user, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_17_101521) do
+ActiveRecord::Schema.define(version: 2020_11_17_114919) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,8 @@ ActiveRecord::Schema.define(version: 2020_11_17_101521) do
     t.date "date"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_offers_on_user_id"
   end
 
   create_table "reviews", force: :cascade do |t|
@@ -50,6 +52,7 @@ ActiveRecord::Schema.define(version: 2020_11_17_101521) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "offers", "users"
   add_foreign_key "reviews", "offers"
   add_foreign_key "reviews", "users"
 end


### PR DESCRIPTION
#Creation d'une migration 
    rails g migration AddForeignKeyToOffer user:references
#Ajout du Offer Belongs_to user et User Has_many: Offer
#Ajout des validations supplémentaires dans Model Offer
   validates :title, presence: true
  validates :description, presence: true
  validates :price, presence: true, numericality: true
  validates :date, presence: true


Verification dans Rails C de la création d'une Offre avec success

  Offer Create (10.8ms)  INSERT INTO "offers" ("title", "description", "price", "date", "created_at", "updated_at", "user_id") VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING "id"  [["title", "assassinat"], ["description", "avec le chandelier"], ["price", 14000], ["date", 20201220], ["created_at", "2020-11-17 12:12:49.861199"], ["updated_at", "2020-11-17 12:12:49.861199"], ["user_id", 1]]
   (2.6ms)  COMMIT
=> true
[13] pry(main)> offer1
=> #<Offer:0x00007fb61dadb418
 id: 1,
 title: "assassinat",
 description: "avec le chandelier",
 price: 14000,
 date: 20201220,
 created_at: Tue, 17 Nov 2020 12:12:49 UTC +00:00,
 updated_at: Tue, 17 Nov 2020 12:12:49 UTC +00:00,
 user_id: 1>